### PR TITLE
Clarify role of `repo.anaconda.com`

### DIFF
--- a/content/posts/anaconda-tos-2024/index.md
+++ b/content/posts/anaconda-tos-2024/index.md
@@ -2,6 +2,11 @@
 title: "Anaconda's 2024 terms of service changes"
 subtitle: "What they mean (I think), what to do, and what not to do."
 date: "2024-08-25"
+author:
+  - name: "Matt Fisher"
+    orcid: "0000-0003-3260-5445"
+  - name: "Jaime Rodríguez-Guerra Pedregal"
+    orcid: "0000-0001-8974-1566"
 categories:
   - "conda"
 ---

--- a/content/posts/anaconda-tos-2024/index.md
+++ b/content/posts/anaconda-tos-2024/index.md
@@ -134,9 +134,10 @@ There are many other options, but this one is the most straightforward, in my vi
 ### What not to do
 
 * Don't leave the Anaconda ecosystem -- the open source community has our backs.
-* Don't block <https://anaconda.org> in your corporate network.
+* Don't block `[conda].anaconda.org` in your corporate network.
   It is free to use for free channels like `"conda-forge"`.
   If and when that changes, the Conda Forge community will provide robust alternatives.
+  Note you can block `repo.anaconda.com` to prevent access to the most common access point of `defaults`.
 * Don't create a policy preventing installation or use of the `conda` command.
 
 


### PR DESCRIPTION
`defaults` is usually served via `repo.anaconda.com`. `conda-forge` comes from `conda.anaconda.org`. This allows folks to easily block one but not the other. Might be helpful to add this to the post.